### PR TITLE
fix(tui): load sidebar from source entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This approach allows you to dynamically include rules automatically like style g
 guidance on specific actions, etc. Unlike skills, which are called on by the agent, rules use a simple matching
 approach.
 
-> _Note:_ The name `opencode-rules` is to be concise about what this plugin does. It is in no way affiliated with Anomaly Co. or
+> [!NOTE]
+> The name `opencode-rules` is to be concise about what this plugin does. It is in no way affiliated with Anomaly Co. or
 > the official OpenCode project.
 
 ## Features
@@ -199,7 +200,8 @@ match: any
   - `any` (default): Rule applies if ANY declared condition matches
   - `all`: Rule applies only if ALL declared conditions match
 
-**Note:** When a runtime context value is unavailable (e.g., not in a git repository), that dimension is treated as a non-match.
+> [!NOTE] 
+> When a runtime context value is unavailable (e.g., not in a git repository), that dimension is treated as a non-match.
 
 ### Matching Behavior
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     },
     "./tui": {
       "types": "./dist/tui/index.d.ts",
-      "import": "./dist/tui/index.js"
+      "import": "./tui/index.tsx"
     }
   },
   "peerDependencies": {

--- a/src/active-rules-state.ts
+++ b/src/active-rules-state.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
-import { createDebugLog } from './debug.js';
+import { createDebugLog } from './debug';
 
 const debugLog = createDebugLog();
 

--- a/src/rule-discovery.ts
+++ b/src/rule-discovery.ts
@@ -5,12 +5,12 @@
 import { stat, readFile, readdir } from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { createDebugLog } from './debug.js';
+import { createDebugLog } from './debug';
 import {
   parseRuleMetadata,
   stripFrontmatter,
   type RuleMetadata,
-} from './rule-metadata.js';
+} from './rule-metadata';
 
 const debugLog = createDebugLog();
 

--- a/tui/data/rules.ts
+++ b/tui/data/rules.ts
@@ -1,7 +1,7 @@
 // tui/data/rules.ts
-import { discoverRuleFiles, getCachedRule } from '../../src/rule-discovery.js';
-import type { RuleMetadata } from '../../src/rule-metadata.js';
-import { readActiveRulesState } from '../../src/active-rules-state.js';
+import { discoverRuleFiles, getCachedRule } from '../../src/rule-discovery';
+import type { RuleMetadata } from '../../src/rule-metadata';
+import { readActiveRulesState } from '../../src/active-rules-state';
 import path from 'path';
 
 /** Represents a rule as displayed in the sidebar */

--- a/tui/index.tsx
+++ b/tui/index.tsx
@@ -1,7 +1,7 @@
 // tui/index.tsx
 /** @jsxImportSource @opentui/solid */
 import type { TuiPlugin } from '@opencode-ai/plugin/tui';
-import { SidebarContent } from './slots/sidebar-content.js';
+import { SidebarContent } from './slots/sidebar-content';
 
 const id = 'opencode-rules' as const;
 

--- a/tui/slots/sidebar-content.tsx
+++ b/tui/slots/sidebar-content.tsx
@@ -10,7 +10,7 @@ import {
   type JSX,
 } from 'solid-js';
 import type { TuiPluginApi, TuiTheme } from '@opencode-ai/plugin/tui';
-import { loadSidebarRules, type SidebarRuleEntry } from '../data/rules.js';
+import { loadSidebarRules, type SidebarRuleEntry } from '../data/rules';
 
 interface SidebarContentProps {
   sessionId: string;


### PR DESCRIPTION
## Summary

The current TUI does not load properly as of opencode v1.4.0 (havent tested on older versions). 

I have made changes according to how official opencode plugins are working - like `@tarquinen/opencode-dcp@beta` 

- export the TUI entry from source instead of compiled dist
- switch sidebar imports to source-resolvable module specifiers
- restore TUI loading on current OpenCode/Bun runtime

## Verification

> opencode-rules@0.6.3 test:run
> vitest run

 RUN  v1.6.1

 ✓ src/debug.test.ts  (4 tests) 4ms
 ✓ src/mcp-tools.test.ts  (4 tests) 3ms
 ✓ src/session-store.test.ts  (6 tests) 5ms
 ✓ src/message-context.test.ts  (22 tests) 8ms
 ✓ src/project-fingerprint.test.ts  (18 tests) 21ms
 ✓ src/git-branch.test.ts  (11 tests) 13ms
 ✓ src/runtime.tool-ids.test.ts  (7 tests) 24ms
 ✓ src/index.rules.test.ts  (94 tests) 204ms
 ✓ src/active-rules-state.test.ts  (17 tests) 366ms
 ✓ src/index.integration.test.ts  (41 tests) 282ms
 ✓ src/index.test.ts  (16 tests) 302ms
 ✓ tui/data/rules.test.ts  (35 tests) 379ms
 ✓ src/index.runtime.test.ts  (44 tests) 487ms

 Test Files  13 passed (13)
      Tests  319 passed (319)
   Start at  13:04:30
   Duration  1.56s (transform 1.72s, setup 0ms, collect 3.48s, tests 2.10s, environment 4ms, prepare 2.38s)

---

> opencode-rules@0.6.3 build
> tsc

https://github.com/frap129/opencode-rules/issues/10