### PR TITLE
fix: add .js extensions to relative imports for strict ESM loaders

### DIFF
--- a/src/active-rules-state.ts
+++ b/src/active-rules-state.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
-import { createDebugLog } from './debug';
+import { createDebugLog } from './debug.js';
 
 const debugLog = createDebugLog();
 

--- a/src/rule-discovery.ts
+++ b/src/rule-discovery.ts
@@ -5,12 +5,12 @@
 import { stat, readFile, readdir } from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { createDebugLog } from './debug';
+import { createDebugLog } from './debug.js';
 import {
   parseRuleMetadata,
   stripFrontmatter,
   type RuleMetadata,
-} from './rule-metadata';
+} from './rule-metadata.js';
 
 const debugLog = createDebugLog();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "jsx": "react-jsx",
     "outDir": "./dist",

--- a/tui/data/rules.ts
+++ b/tui/data/rules.ts
@@ -1,7 +1,7 @@
 // tui/data/rules.ts
-import { discoverRuleFiles, getCachedRule } from '../../src/rule-discovery';
-import type { RuleMetadata } from '../../src/rule-metadata';
-import { readActiveRulesState } from '../../src/active-rules-state';
+import { discoverRuleFiles, getCachedRule } from '../../src/rule-discovery.js';
+import type { RuleMetadata } from '../../src/rule-metadata.js';
+import { readActiveRulesState } from '../../src/active-rules-state.js';
 import path from 'path';
 
 /** Represents a rule as displayed in the sidebar */

--- a/tui/index.tsx
+++ b/tui/index.tsx
@@ -1,7 +1,7 @@
 // tui/index.tsx
 /** @jsxImportSource @opentui/solid */
 import type { TuiPlugin } from '@opencode-ai/plugin/tui';
-import { SidebarContent } from './slots/sidebar-content';
+import { SidebarContent } from './slots/sidebar-content.js';
 
 const id = 'opencode-rules' as const;
 

--- a/tui/slots/sidebar-content.tsx
+++ b/tui/slots/sidebar-content.tsx
@@ -10,7 +10,7 @@ import {
   type JSX,
 } from 'solid-js';
 import type { TuiPluginApi, TuiTheme } from '@opencode-ai/plugin/tui';
-import { loadSidebarRules, type SidebarRuleEntry } from '../data/rules';
+import { loadSidebarRules, type SidebarRuleEntry } from '../data/rules.js';
 
 interface SidebarContentProps {
   sessionId: string;


### PR DESCRIPTION
Add explicit .js extensions to all relative imports to fix module resolution failures in strict ESM environments (Electron, Desktop).

Also switch tsconfig to moduleResolution: NodeNext to enforce extensions at compile time and prevent future regressions.

Fixes #16