### PR TITLE
build: switch to NodeNext module resolution for strict ESM enforcement

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "jsx": "react-jsx",
     "outDir": "./dist",


### PR DESCRIPTION
Change tsconfig from bundler to NodeNext moduleResolution. This makes TypeScript enforce .js extensions at compile time, preventing the class of ESM resolution failures described in issue #16.

The .js extension fixes were already applied in a previous commit. This change prevents future regressions by making extensionless imports a compile-time error.

Fixes #16